### PR TITLE
Fix maven version Issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.0.0-M2</version>


### PR DESCRIPTION
## Error

When use `versions:display-plugin-updates` maven produce a error:

```
[WARNING] Project does not define minimum Maven version, default is: 2.0
[INFO] Plugins require minimum Maven version of: null
[INFO] 
[ERROR] Project does not define required minimum version of Maven.
[ERROR] Update the pom.xml to contain
[ERROR]     <prerequisites>
[ERROR]       <maven>null</maven>
[ERROR]     </prerequisites>
```

## How to reproduce

Execute the maven plugin version check goal:

`mvn versions:display-plugin-updates`

## Explanation

Versions plugin 2.2 search for section  `<prerequisites>`, which is not used by recent versions of `maven-enforcer`. The latest version (2.7) search for the correct section but is not used by maven by default, so must be explicit defined on pom.

## Considerations

Run compile goal before check plugin updates to force maven to download de 2.7 version of versions plugin.